### PR TITLE
Default value of `color` should be `blue`

### DIFF
--- a/DataProcessingService/main.go
+++ b/DataProcessingService/main.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-var color string = "green"
+var color string = "blue"
 var env string = "local"
 var datastoreURL string = "http://verylargedatastore:8080"
 var port string = "3000"


### PR DESCRIPTION
The [Setup a local development environment](https://www.getambassador.io/docs/telepresence/latest/quick-start/qs-go/#4-set-up-a-local-development-environment) section of the "Telepresence Quick Start - Go" docs use `fresh` to run the go server and state that the default color is `blue`. The default is actually `green`.