### PR TITLE
Add `go.mod` to resolve `fresh` build failure when using Go `1.16`

### DIFF
--- a/DataProcessingService/go.mod
+++ b/DataProcessingService/go.mod
@@ -1,0 +1,1 @@
+module github.com/datawire/edgey-corp-go/DataProcessingService


### PR DESCRIPTION
[These docs](https://www.getambassador.io/docs/telepresence/latest/quick-start/qs-go/#4-set-up-a-local-development-environment) state you should run `$GOPATH/bin/fresh` to build/live reload this project. If you're running Go `1.16` the `$GOPATH/bin/fresh` command results in the following error (due to the lack of a `go.mod` file):
```sh
$ $GOPATH/bin/fresh
15:12:41 runner      | InitFolders
15:12:41 runner      | mkdir ./tmp
15:12:41 runner      | mkdir ./tmp: file exists
15:12:41 watcher     | Watching .
15:12:41 main        | Waiting (loop 1)...
15:12:41 main        | receiving first event /
15:12:41 main        | sleeping for 600 milliseconds
15:12:42 main        | flushing events
15:12:42 main        | Started! (5 Goroutines)
15:12:42 main        | remove tmp/runner-build-errors.log: no such file or directory
15:12:42 build       | Building...
15:12:42 main        | Build Failed: 
 go: cannot find main module, but found .git/config in /Users/redacted/dev/github.com/datawire/edgey-corp-go
        to create a module there, run:
        cd .. && go mod init
```